### PR TITLE
Fix bad TraceLine filter

### DIFF
--- a/gamemodes/prop_hunt/gamemode/cl_init.lua
+++ b/gamemodes/prop_hunt/gamemode/cl_init.lua
@@ -302,7 +302,16 @@ function PHEDrawPropselectHalos()
 			trace.start = LocalPlayer():EyePos() + Vector(0, 0, 8)
 			trace.endpos = LocalPlayer():EyePos() + Vector(0, 0, 8) + LocalPlayer():EyeAngles():Forward() * 100
 		end
-		trace.filter = ents.FindByClass("ph_prop")
+
+		local filter = {} -- We need to filter out players and the ph_prop.
+
+		for k,v in pairs(ents.GetAll()) do
+			if v:GetClass() == "ph_prop" or v:GetClass() == "player" then
+				table.insert(filter, v)
+			end
+		end
+
+		trace.filter = filter
 
 		local trace2 = util.TraceLine(trace)
 		if trace2.Entity && trace2.Entity:IsValid() && table.HasValue(PHE.USABLE_PROP_ENTITIES, trace2.Entity:GetClass()) then

--- a/gamemodes/prop_hunt/gamemode/init.lua
+++ b/gamemodes/prop_hunt/gamemode/init.lua
@@ -764,7 +764,16 @@ function PlayerPressedKey(pl, key)
 				trace.start = pl:EyePos() + Vector(0, 0, 8)
 				trace.endpos = pl:EyePos() + Vector(0, 0, 8) + pl:EyeAngles():Forward() * 100
 			end
-			trace.filter = ents.FindByClass("ph_prop")
+
+			local filter = {} -- We need to filter out players and the ph_prop.
+
+			for k,v in pairs(ents.GetAll()) do
+				if v:GetClass() == "ph_prop" or v:GetClass() == "player" then
+					table.insert(filter, v)
+				end
+			end
+
+			trace.filter = filter
 
 			local trace2 = util.TraceLine(trace)
 			if trace2.Entity && trace2.Entity:IsValid() && table.HasValue(PHE.USABLE_PROP_ENTITIES, trace2.Entity:GetClass()) then


### PR DESCRIPTION
The default filter only ignores `ph_prop` and not players, this merge corrects it and means that the precise pick function of prop hunt is not perpetually broken.

This typically happens on servers that use pointshops to set the player model to something other than a tiny cube on prop's turn.

![Hey I just cloned you, and this is crazy, but here's my PR, merge me maybe](https://i.imgur.com/iMzIdTI.png)
